### PR TITLE
Api credentials are being validated before save.

### DIFF
--- a/Model/Config/Backend/Validate.php
+++ b/Model/Config/Backend/Validate.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Smaily\SmailyForMagento\Model\Config\Backend;
+
+use \Magento\Framework\Model\Context;
+use \Magento\Framework\Registry;
+use \Magento\Framework\App\Config\ScopeConfigInterface;
+use \Magento\Framework\App\Cache\TypeListInterface;
+use Smaily\SmailyForMagento\Helper\Data as Helper;
+
+class Validate extends \Magento\Framework\App\Config\Value
+{
+    private $helper;
+
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        Helper $helper,
+        array $data = []
+    ) {
+        $this->helper = $helper;
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    public function beforeSave()
+    {
+        $subdomain = $this->getData('groups/general/fields/subdomain')['value'];
+        $username = $this->getData('groups/general/fields/username')['value'];
+        $password = $this->getData('groups/general/fields/password')['value'];
+
+        if (empty($subdomain)) {
+            throw new \Magento\Framework\Exception\ValidatorException(__('Subdomain is required.'));
+        } elseif (empty($username)) {
+            throw new \Magento\Framework\Exception\ValidatorException(__('Username is required.'));
+        } elseif (empty($password)) {
+            throw new \Magento\Framework\Exception\ValidatorException(__('Password is required.'));
+        }
+
+        $validated = $this->helper->validateApiCredentrials($subdomain, $username, $password);
+        if (isset($validated) && $validated === false) {
+            throw new \Magento\Framework\Exception\ValidatorException(__('Check API credentials, unauthorized.'));
+        }
+
+        parent::beforeSave();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,13 +17,17 @@
                 </field>
                 <field id="subdomain" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Subdomain</label>
+                    <backend_model>Smaily\SmailyForMagento\Model\Config\Backend\Validate</backend_model>
+                    <validate>required-entry</validate>
                     <comment>For example "demo" from https://demo.sendsmaily.net/</comment>
                 </field>
                  <field id="username" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>API username</label>
+                    <validate>required-entry</validate>    
                 </field>
                 <field id="password" translate="label" type="password" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>API password</label>
+                    <validate>required-entry</validate>    
                     <comment><![CDATA[<a href="http://help.smaily.com/en/support/solutions/articles/16000062943-create-api-user" target="_blank">How to create API credentials?</a>]]></comment>
                 </field>
             </group>


### PR DESCRIPTION
Helper uses curl with dependecy injection.
Subdomain, username and password are required fields.
If there is an error with credentials, settings will not be saved.

Improves user experience in refrence to the issue #15 