### PR TITLE
Hotfix/compilation php56

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -16,6 +16,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     const XML_PATH = 'smaily/';
 
+    /**
+     * Settings page subscribe group id-s.
+     */
+    protected $subscribeSettings = [
+        'enableNewsletterSubscriptions',
+        'enableCaptcha',
+        'captchaType',
+        'captchaApiKey',
+        'captchaApiSecret'
+    ];
+
+    /**
+     * Settings page sync group id-s.
+     */
+    protected $syncSettings = ['fields', 'frequency', 'enableCronSync'];
+
+    /**
+     * Settings page abandoned group id-s.
+     */
+    protected $abandonedSettings = ['autoresponderId', 'syncTime', 'productfields', 'enableAbandonedCart'];
+
     private $connection;
 
     public function __construct(
@@ -154,22 +175,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getGeneralConfig($code, $storeId = null)
     {
         $tab = 'general';
-        if (in_array(
-            $code,
-            ['enableNewsletterSubscriptions',
-            'enableCaptcha',
-            'captchaType',
-            'captchaApiKey',
-            'captchaApiSecret'
-            ],
-            true
-        )) {
+        if (in_array($code, $this->subscribeSettings, true)) {
             $tab = 'subscribe';
         }
-        if (in_array($code, ['fields', 'frequency', 'enableCronSync'], true)) {
+        if (in_array($code, $this->syncSettings, true)) {
             $tab = 'sync';
         }
-        if (in_array($code, ['autoresponderId', 'syncTime', 'productfields', 'enableAbandonedCart'], true)) {
+        if (in_array($code, $this->abandonedSettings, true)) {
             $tab = 'abandoned';
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -16,27 +16,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     const XML_PATH = 'smaily/';
 
-    /**
-     * Settings page subscribe group id-s.
-     */
-    const SUBSCRIBE_SETTINGS = [
-        'enableNewsletterSubscriptions',
-        'enableCaptcha',
-        'captchaType',
-        'captchaApiKey',
-        'captchaApiSecret'
-    ];
-
-    /**
-     * Settings page sync group id-s.
-     */
-    const SYNC_SETTINGS = ['fields', 'frequency', 'enableCronSync'];
-
-    /**
-     * Settings page abandoned group id-s.
-     */
-    const ABANDONED_SETTINGS = ['autoresponderId', 'syncTime', 'productfields', 'enableAbandonedCart'];
-
     private $connection;
 
     public function __construct(
@@ -175,13 +154,22 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getGeneralConfig($code, $storeId = null)
     {
         $tab = 'general';
-        if (in_array($code, self::SUBSCRIBE_SETTINGS, true)) {
+        if (in_array(
+            $code,
+            ['enableNewsletterSubscriptions',
+            'enableCaptcha',
+            'captchaType',
+            'captchaApiKey',
+            'captchaApiSecret'
+            ],
+            true
+        )) {
             $tab = 'subscribe';
         }
-        if (in_array($code, self::SYNC_SETTINGS, true)) {
+        if (in_array($code, ['fields', 'frequency', 'enableCronSync'], true)) {
             $tab = 'sync';
         }
-        if (in_array($code, self::ABANDONED_SETTINGS, true)) {
+        if (in_array($code, ['autoresponderId', 'syncTime', 'productfields', 'enableAbandonedCart'], true)) {
             $tab = 'abandoned';
         }
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Usually a good place to start would be to check Magento CRON's Schedule Ahead fo
 
 ## Changelog
 
+### 1.0.1
+
+#### Bugfix
+
+- Fix PHP 5.6 compilation issues
+
 ### 1.0.0
 
 - Make using CAPTCHA optional for better integration with pop-up forms

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smaily/smailyformagento",
   "description": "Magento 2 Smaily extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "magento2-module",
   "license": "GPL-3.0",
   "authors": [

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -16,7 +16,7 @@
                 </block>
                 <block class="Magento\Framework\View\Element\Template" name="smaily.captcha.js" template="Smaily_SmailyForMagento::captcha.phtml" />
             </container>
-            <block class="Smaily\SmailyForMagento\Block\ReCaptcha" name="smaily.recaptcha" template="Smaily_SmailyForMagento::reCaptcha.phtml" cacheable="false" ifconfig="smaily/general/enable"/>
+            <block class="Smaily\SmailyForMagento\Block\ReCaptcha" name="smaily.recaptcha" template="Smaily_SmailyForMagento::reCaptcha.phtml" ifconfig="smaily/general/enable"/>
         </referenceContainer>
         <move element="form.subscribe" destination="smaily.additional.info" before="smaily.captcha" />
     </body>


### PR DESCRIPTION
Fixes errors
 A little bit smarter [now ](https://www.php.net/manual/en/language.oop5.constants.php#100142)
>PHP Fatal error:  Arrays are not allowed in class constants in /var/www/html/vendor/smaily/smailyformagento/Helper/Data.php on line 28

And Varnish PageCache Test 
` cacheable="false"` was a mistake.