### PR TITLE
Hotfix/rss feed accented letters

### DIFF
--- a/Controller/Rss/Feed.php
+++ b/Controller/Rss/Feed.php
@@ -108,11 +108,11 @@ class Feed extends \Magento\Framework\App\Action\Action
             // Feed Item array
             $items[] =
             '<item>' .
-                '<title>' . htmlentities($product->getName()) . '</title>' .
+                '<title><![CDATA[' . $product->getName() . ']]></title>' .
                 '<link>' . $url . '</link>' .
                 '<guid isPermaLink="True">' . $url . '</guid>' .
                 '<pubDate>' . date('D, d M Y H:i:s', $createTime) . '</pubDate>' .
-                '<description>' . htmlentities(($product->getData('description'))) . '</description>' .
+                '<description><![CDATA[' . $product->getData('description') . ']]></description>' .
                 '<enclosure url="' . $image . '" />' .
                 '<smly:price>' . $splcPrice . '</smly:price>' .
                 $discount_fields .
@@ -123,7 +123,7 @@ class Feed extends \Magento\Framework\App\Action\Action
         '<?xml version="1.0" encoding="utf-8"?>' .
         '<rss xmlns:smly="https://sendsmaily.net/schema/editor/rss.xsd" version="2.0">
             <channel>
-            <title>' . $this->helperData->getConfigValue('general/store_information/name') . '</title>
+            <title><![CDATA[' . $this->helperData->getConfigValue('general/store_information/name') . ']]></title>
             <link>' . $baseUrl . '</link>
             <description>Product Feed</description>
             <lastBuildDate>' . date('D, d M Y H:i:s') . '</lastBuildDate>' .

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Usually a good place to start would be to check Magento CRON's Schedule Ahead fo
 
 ## Changelog
 
+### 1.0.2
+
+### Bugfix
+
+- Fix RSS-feed not rendering with special characters
+
 ### 1.0.1
 
 #### Bugfix

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "smaily/smailyformagento",
   "description": "Magento 2 Smaily extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "magento2-module",
   "license": "GPL-3.0",
   "authors": [


### PR DESCRIPTION
Fixes #30 

Current implementation converted special characters to `httmlentities` that broke XML parser.

I have removed `htmlentities` function and return title and description in `<![CDATA[]]>` blocks.

![image](https://user-images.githubusercontent.com/22918359/68876072-8aecd400-070c-11ea-84f5-aeee6fb64756.png)

There is still an issue I fount that somehow description has `htmlentities` conversion by default. Maybe it's coming from importing products that had entities in them.

After I edited a product they disappeared and were replaced by symbols. Also when I created a new product no entities were used instead of special characters. Can RSS elements have entities in them or should I run `html_entities_decode` before?