### PR TITLE
Magento 2.4 compatibility

### DIFF
--- a/.sandbox/entrypoint.sh
+++ b/.sandbox/entrypoint.sh
@@ -11,6 +11,15 @@ while !(mysql_ready); do
     echo "Waiting for MySQL to finish start up..."
 done
 
+# Wait for Elasticsearch to start.
+elastic_ready() {
+    curl -X GET "elastic:9200/_cat/nodes?v=true&pretty" > /dev/null 2>&1
+}
+while !(elastic_ready); do
+    sleep 1
+    echo "Waiting for Elasticsearch to finish start up..."
+done
+
 # Install sample data if requested.
 if [ "${MAGENTO_SAMPLEDATA}" = "1" ]; then
     echo "Installing sample-data..."
@@ -31,6 +40,8 @@ bin/magento setup:install \
     --use-secure=0 \
     --base-url-secure= \
     --use-secure-admin=0 \
+    --elasticsearch-host=elastic \
+    --elasticsearch-port=9200 \
     --admin-firstname=Smaily \
     --admin-lastname=DevOps \
     --admin-email=${MAGENTO_ADMIN_EMAIL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3-apache
 
-ENV MAGENTO_VERSION 2.3.6
+ENV MAGENTO_VERSION 2.4.2-p1
 ENV COMPOSER_HOME /var/www/.composer
 
 # Install Magento requirements.

--- a/Plugin/Captcha.php
+++ b/Plugin/Captcha.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Smaily\SmailyForMagento\Plugin;
+
+use Smaily\SmailyForMagento\Helper\Config;
+use Smaily\SmailyForMagento\Helper\Data;
+
+class Captcha
+{
+    protected $captchaHelper;
+    protected $captchaResolver;
+    protected $messageManager;
+    protected $redirect;
+    protected $request;
+    protected $response;
+    protected $storeManager;
+
+    protected $config;
+    protected $dataHelper;
+
+    /**
+     * Class constructor.
+     *
+     * @access public
+     * @return void
+     */
+    public function __construct(
+        \Magento\Captcha\Helper\Data $captchaHelper,
+        \Magento\Captcha\Observer\CaptchaStringResolver $captchaResolver,
+        \Magento\Framework\App\Request\Http $request,
+        \Magento\Framework\App\Response\RedirectInterface $redirect,
+        \Magento\Framework\Message\ManagerInterface $messageManager,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        Config $config,
+        Data $dataHelper
+    ) {
+        $this->captchaHelper = $captchaHelper;
+        $this->captchaResolver = $captchaResolver;
+        $this->messageManager = $messageManager;
+        $this->redirect = $redirect;
+        $this->request = $request;
+        $this->storeManager = $storeManager;
+
+        $this->config = $config;
+        $this->dataHelper = $dataHelper;
+    }
+
+    /**
+     * Run additional logic when Newsletter Subscriber is subscribed.
+     *
+     * @param \Magento\Newsletter\Controller\Subscriber\NewAction $context
+     * @access public
+     * @return void
+     */
+    public function aroundExecute(\Magento\Newsletter\Controller\Subscriber\NewAction $context, callable $proceed, ...$args)
+    {
+        $website = $this->storeManager->getWebsite();
+
+        // Validate CAPTCHA, if enabled.
+        if (
+            $this->config->isEnabled($website) === true &&
+            $this->config->isSubscriberOptInEnabled($website) === true &&
+            $this->config->isSubscriberOptInCaptchaEnabled($website) === true
+        ) {
+            $captchaType = $this->config->getSubscriberOptInCaptchaType($website);
+
+            if ($captchaType === 'google_captcha') {
+                $challenge = $this->request->getParam('g-recaptcha-response');
+
+                if ($this->dataHelper->verifyGoogleCaptchaResponse($challenge) === false) {
+                    return $this->redirectWithMessage($context, __('Incorrect CAPTCHA.'));
+                }
+            } elseif ($captchaType === 'magento_captcha') {
+                $formId = 'smaily_captcha';
+                $challenge = $this->captchaResolver->resolve($this->request, $formId);
+
+                if ($this->captchaHelper->getCaptcha($formId)->isCorrect($challenge) === false) {
+                    return $this->redirectWithMessage($context, __('Incorrect CAPTCHA.'));
+                }
+            }
+        }
+
+        // Execute wrapped callback.
+        return $proceed(...$args);
+    }
+
+    /**
+     * Helper method to redirect back to referer with an error message.
+     *
+     * @param \Magento\Newsletter\Controller\Subscriber\NewAction $context
+     * @param string $message
+     * @access protected
+     * @return void
+     */
+    protected function redirectWithMessage(\Magento\Newsletter\Controller\Subscriber\NewAction $context, $message)
+    {
+        $actionFlag = $context->getActionFlag();
+        $response = $context->getResponse();
+
+        $this->messageManager->getMessages(true);
+        $this->messageManager->addErrorMessage($message);
+        $actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
+        $response->setRedirect($this->redirect->getRefererUrl());
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     - ./:/var/www/html/app/code/Smaily/SmailyForMagento
     depends_on:
     - db
+    - elastic
 
   db:
     container_name: magento2_db
@@ -36,6 +37,17 @@ services:
     - MYSQL_ROOT_PASSWORD=root
     volumes:
     - db-data:/var/lib/mysql
+
+  elastic:
+    container_name: magento2_elastic
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3
+    ports:
+    - '9200:9200'
+    - '9300:9300'
+    environment:
+    - discovery.type=single-node
+    volumes:
+    - elastic-data:/usr/share/elasticsearch/data
 
   phpmyadmin:
     container_name: magento2_phpmyadmin
@@ -55,3 +67,5 @@ volumes:
     name: docker_magento2-data
   db-data:
     name: docker_magento2-db-data
+  elastic-data:
+    name: docker_magento2-elastic-data

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,6 +7,9 @@
     </type>
 
     <!-- Intercept Newsletter Subscriber opt-in -->
+    <type name="Magento\Newsletter\Controller\Subscriber\NewAction">
+        <plugin name="Smaily_SmailyForMagento_Plugin_Captcha" type="Smaily\SmailyForMagento\Plugin\Captcha" />
+    </type>
     <type name="Magento\Newsletter\Model\Subscriber">
         <plugin name="Smaily_SmailyForMagento_Plugin_OptIn" type="Smaily\SmailyForMagento\Plugin\OptIn" />
     </type>
@@ -47,6 +50,7 @@
     <virtualType name="Smaily\SmailyForMagento\Logger\Cron\AbandonedCart" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers" xsi:type="array">
+                <item name="debug" xsi:type="object">Smaily\SmailyForMagento\Model\Logger\Handler\Cron\AbandonedCart</item>
                 <item name="system" xsi:type="object">Smaily\SmailyForMagento\Model\Logger\Handler\Cron\AbandonedCart</item>
             </argument>
         </arguments>
@@ -54,6 +58,7 @@
     <virtualType name="Smaily\SmailyForMagento\Logger\Cron\SubscribersSync" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers" xsi:type="array">
+                <item name="debug" xsi:type="object">Smaily\SmailyForMagento\Model\Logger\Handler\Cron\SubscribersSync</item>
                 <item name="system" xsi:type="object">Smaily\SmailyForMagento\Model\Logger\Handler\Cron\SubscribersSync</item>
             </argument>
         </arguments>


### PR DESCRIPTION
Reworks CAPTCHA validation and opt-in request trigger point. It is more foolproof to trigger CAPTCHA validation around `Magento\Newsletter\Controller\Subscribe\NewAction::execute` callback, and handle opt-in request triggering when confirmation success email is sent by Magento.

Also adds ELK (Elasticsearch) stack to sandbox environment;