### PR TITLE
Rework Newsletter Subscribers synchronization last synchronization tracking

### DIFF
--- a/Block/Adminhtml/Form/Field/Datetime.php
+++ b/Block/Adminhtml/Form/Field/Datetime.php
@@ -16,8 +16,7 @@ class Datetime extends \Magento\Config\Block\System\Config\Form\Field
         \Magento\Backend\Block\Template\Context $context,
         array $data = [],
         ?\Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer = null
-    )
-    {
+    ) {
         $this->localeDate = $context->getLocaleDate();
         parent::__construct($context, $data, $secureRenderer);
     }

--- a/Block/Adminhtml/Form/Field/Datetime.php
+++ b/Block/Adminhtml/Form/Field/Datetime.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Smaily\SmailyForMagento\Block\Adminhtml\Form\Field;
+
+class Datetime extends \Magento\Config\Block\System\Config\Form\Field
+{
+    protected $localeDate;
+
+    /**
+     * Class constructor.
+     *
+     * @access public
+     * @return void
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        array $data = [],
+        ?\Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer = null
+    )
+    {
+        $this->localeDate = $context->getLocaleDate();
+        parent::__construct($context, $data, $secureRenderer);
+    }
+
+    /**
+     * Retrieve HTML markup for given form element.
+     *
+     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
+     * @access public
+     * @return string
+     */
+    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        // Set date and time formatting.
+        $element->setDateFormat(\Magento\Framework\Stdlib\DateTime::DATE_INTERNAL_FORMAT);
+        $element->setTimeFormat("HH:mm:ss");
+
+        // Convert time to local timezone.
+        $value = $element->getValue();
+        if (!empty($value)) {
+            $tz = new \DateTimeZone($this->localeDate->getConfigTimezone($element->getScope(), $element->getScopeId()));
+            $dt = new \DateTime($value, new \DateTimeZone('UTC'));
+
+            $element->setValue($dt->setTimezone($tz));
+        }
+
+        // Call parent class method.
+        return parent::render($element);
+    }
+}

--- a/Block/Adminhtml/Form/Field/Datetime.php
+++ b/Block/Adminhtml/Form/Field/Datetime.php
@@ -14,11 +14,10 @@ class Datetime extends \Magento\Config\Block\System\Config\Form\Field
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
-        array $data = [],
-        ?\Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer = null
+        array $data = []
     ) {
         $this->localeDate = $context->getLocaleDate();
-        parent::__construct($context, $data, $secureRenderer);
+        parent::__construct($context, $data);
     }
 
     /**

--- a/Cron/SubscribersSync.php
+++ b/Cron/SubscribersSync.php
@@ -65,8 +65,6 @@ class SubscribersSync
      */
     public function execute()
     {
-        $nowAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-        $lastSyncedAt = $this->subscribersSyncStateCollection->getLastSyncedAt();
         $websites = $this->storeManager->getWebsites();
 
         $this->logger->info('Starting Newsletter Subscribers synchronization CRON job...');
@@ -83,13 +81,16 @@ class SubscribersSync
                 continue;
             }
 
+            $nowAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $lastSyncedAt = $this->subscribersSyncStateCollection->getLastSyncedAt($website->getId());
+
             // Synchronize Newsletter Subscribers.
             $this->optOutNewsletterSubscribers($website);
             $this->syncNewsletterSubscribers($website, $lastSyncedAt);
-        }
 
-        // Update last synchronization date.
-        $this->subscribersSyncStateCollection->updateLastSyncedAt($nowAt);
+            // Update last synchronization date.
+            $this->subscribersSyncStateCollection->updateLastSyncedAt($website->getId(), $nowAt);
+        }
     }
 
     /**

--- a/Cron/SubscribersSync.php
+++ b/Cron/SubscribersSync.php
@@ -5,7 +5,6 @@ namespace Smaily\SmailyForMagento\Cron;
 use Smaily\SmailyForMagento\Helper\Config;
 use Smaily\SmailyForMagento\Helper\Data;
 use Smaily\SmailyForMagento\Model\HTTP\ClientException;
-use Smaily\SmailyForMagento\Model\ResourceModel\SubscribersSyncState\Collection as SubscribersSyncStateCollection;
 
 class SubscribersSync
 {
@@ -27,7 +26,6 @@ class SubscribersSync
 
     protected $config;
     protected $dataHelper;
-    protected $subscribersSyncStateCollection;
 
     /**
      * Class constructor.
@@ -42,8 +40,7 @@ class SubscribersSync
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Psr\Log\LoggerInterface $logger,
         Config $config,
-        Data $dataHelper,
-        SubscribersSyncStateCollection $subscribersSyncStateCollection
+        Data $dataHelper
     ) {
         $this->customerCollection = $customerCollection;
         $this->logger = $logger;
@@ -54,7 +51,6 @@ class SubscribersSync
 
         $this->config = $config;
         $this->dataHelper = $dataHelper;
-        $this->subscribersSyncStateCollection = $subscribersSyncStateCollection;
     }
 
     /**
@@ -82,14 +78,14 @@ class SubscribersSync
             }
 
             $nowAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-            $lastSyncedAt = $this->subscribersSyncStateCollection->getLastSyncedAt($website->getId());
+            $lastSyncedAt = $this->config->getSubscribersSyncLastSyncedAt($website->getId());
 
             // Synchronize Newsletter Subscribers.
             $this->optOutNewsletterSubscribers($website);
             $this->syncNewsletterSubscribers($website, $lastSyncedAt);
 
             // Update last synchronization date.
-            $this->subscribersSyncStateCollection->updateLastSyncedAt($website->getId(), $nowAt);
+            $this->config->setSubscribersSyncLastSyncedAt($website->getId(), $nowAt);
         }
     }
 
@@ -112,6 +108,7 @@ class SubscribersSync
 
         $this->logger->info('Synchronizing subscribers from Magento to Smaily...', [
             'batch_size' => self::BATCH_SIZE,
+            'since_dt' => $lastSyncedAt,
         ]);
 
         // Determine list of customer fields to synchronize.

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -28,6 +28,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     const SUBSCRIBERS_SYNC_ENABLED = 'enableCronSync';
     const SUBSCRIBERS_SYNC_FIELDS = 'fields';
     const SUBSCRIBERS_SYNC_FREQUENCY = 'frequency';
+    const SUBSCRIBERS_SYNC_LAST_DT = 'lastSyncedAt';
 
     const ABANDONED_CART_ENABLED = 'enableAbandonedCart';
     const ABANDONED_CART_FIELDS = 'productfields';
@@ -156,6 +157,47 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $fields = $this->getConfigValue(self::SUBSCRIBERS_SYNC_FIELDS, self::GROUP_SUBSCRIBERS_SYNC, $websiteId);
         return !empty($fields) ? explode(',', $fields) : [];
+    }
+
+    /**
+     * Return subscriber's synchronization last date and time in website.
+     *
+     * @param mixed $websiteId
+     * @access public
+     * @return \DateTimeImmutable|null
+     */
+    public function getSubscribersSyncLastSyncedAt($websiteId)
+    {
+        if ($websiteId === null) {
+            throw new \Exception('Missing website ID');
+        }
+
+        $dt = $this->getConfigValue(self::SUBSCRIBERS_SYNC_LAST_DT, self::GROUP_SUBSCRIBERS_SYNC, $websiteId);
+        return empty($dt) ? null : new \DateTimeImmutable($dt, new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * Set subscribers' synchronization date and time in website.
+     *
+     * @param mixed $websiteId
+     * @param \DateTimeImmutable $dt
+     * @access public
+     * @return self
+     */
+    public function setSubscribersSyncLastSyncedAt($websiteId, \DateTimeImmutable $dt)
+    {
+        if ($websiteId === null) {
+            throw new \Exception('Missing website ID');
+        }
+
+        $this->setConfigValue(
+            self::SUBSCRIBERS_SYNC_LAST_DT,
+            $dt->format('Y-m-d H:i:s'),
+            self::GROUP_SUBSCRIBERS_SYNC,
+            $websiteId
+        );
+
+        return $this;
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -278,7 +278,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     private function getConfigValue($setting, $group, $websiteId = null)
     {
         $path = self::SETTINGS_NAMESPACE . '/' . trim($group, '/') . '/' . trim($setting, '/');
-        return $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE, $websiteId);
+        return $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES, $websiteId);
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -34,6 +34,17 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     const ABANDONED_CART_INTERVAL = 'syncTime';
     const ABANDONED_CART_WORKFLOW_ID = 'autoresponderId';
 
+    protected $configInterface;
+
+    public function __construct(
+        \Magento\Framework\App\Helper\Context $context,
+        \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface
+    )
+    {
+        $this->configInterface = $configInterface;
+        parent::__construct($context);
+    }
+
     /**
      * Is module enabled?
      *
@@ -226,5 +237,21 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $path = self::SETTINGS_NAMESPACE . '/' . trim($group, '/') . '/' . trim($setting, '/');
         return $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE, $websiteId);
+    }
+
+    /**
+     * Set Magento main configuration value by field.
+     *
+     * @param string $setting
+     * @param string $value
+     * @param string $group
+     * @param string|null $websiteId
+     * @access private
+     * @return void
+     */
+    private function setConfigValue($setting, $value, $group, $websiteId = null)
+    {
+        $path = self::SETTINGS_NAMESPACE . '/' . trim($group, '/') . '/' . trim($setting, '/');
+        $this->configInterface->saveConfig($path, $value, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES, $websiteId);
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -40,8 +40,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
         \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface
-    )
-    {
+    ) {
         $this->configInterface = $configInterface;
         parent::__construct($context);
     }
@@ -169,7 +168,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     public function getSubscribersSyncLastSyncedAt($websiteId)
     {
         if ($websiteId === null) {
-            throw new \Exception('Missing website ID');
+            throw new \Magento\Framework\Exception\InvalidArgumentException('Missing website ID');
         }
 
         $dt = $this->getConfigValue(self::SUBSCRIBERS_SYNC_LAST_DT, self::GROUP_SUBSCRIBERS_SYNC, $websiteId);
@@ -187,7 +186,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     public function setSubscribersSyncLastSyncedAt($websiteId, \DateTimeImmutable $dt)
     {
         if ($websiteId === null) {
-            throw new \Exception('Missing website ID');
+            throw new \Magento\Framework\Exception\InvalidArgumentException('Missing website ID');
         }
 
         $this->setConfigValue(
@@ -277,8 +276,9 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
      */
     private function getConfigValue($setting, $group, $websiteId = null)
     {
+        $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
         $path = self::SETTINGS_NAMESPACE . '/' . trim($group, '/') . '/' . trim($setting, '/');
-        return $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        return $this->scopeConfig->getValue($path, $scope, $websiteId);
     }
 
     /**
@@ -293,7 +293,8 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
      */
     private function setConfigValue($setting, $value, $group, $websiteId = null)
     {
+        $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
         $path = self::SETTINGS_NAMESPACE . '/' . trim($group, '/') . '/' . trim($setting, '/');
-        $this->configInterface->saveConfig($path, $value, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        $this->configInterface->saveConfig($path, $value, $scope, $websiteId);
     }
 }

--- a/Model/Config/Backend/UTCTime.php
+++ b/Model/Config/Backend/UTCTime.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Smaily\SmailyForMagento\Model\Config\Backend;
+
+class UTCTime extends \Magento\Framework\App\Config\Value
+{
+    /**
+     * Normalize date value to UTC before storing.
+     *
+     * @access public
+     * @return void
+     */
+    public function beforeSave()
+    {
+        $value = $this->getValue();
+
+        if (!empty($value)) {
+            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+            $localeDate = $objectManager->create(\Magento\Framework\Stdlib\DateTime\TimezoneInterface::class);
+
+            $tz = new \DateTimeZone($localeDate->getConfigTimezone($this->getScope(), $this->getScopeId()));
+            $dt = new \DateTime($value, $tz);
+
+            $this->setValue($dt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'));
+        }
+
+        parent::beforeSave();
+    }
+}

--- a/Model/ResourceModel/SubscribersSyncState/Collection.php
+++ b/Model/ResourceModel/SubscribersSyncState/Collection.php
@@ -26,14 +26,16 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     /**
      * Return last synchronization time.
      *
+     * @param integer $websiteId
      * @access public
      * @return \DateTimeImmutable|null
      */
-    public function getLastSyncedAt()
+    public function getLastSyncedAt($websiteId)
     {
         $select = $this->getConnection()
             ->select()
             ->from($this->getMainTable(), ['last_update_at'])
+            ->where('website_id = ?', $websiteId)
             ->limit(1);
 
         $data = $this->getConnection()->fetchRow($select);
@@ -47,17 +49,18 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     /**
      * Update last synchronization time.
      *
-     * @param \DateTimeImmutable $syncAt
+     * @param integer $websiteId
+     * @param mixed $syncAt
      * @access public
      * @return void
      */
-    public function updateLastSyncedAt(\DateTimeImmutable $syncAt)
+    public function updateLastSyncedAt($websiteId, $syncAt)
     {
         $this->getConnection()->insertOnDuplicate(
             $this->getMainTable(),
             [
-                'id' => 1,
-                'last_update_at' => $this->dateTime->gmtDate(null, $syncAt),
+                'website_id' => $websiteId,
+                'last_update_at' => $syncAt !== null ? $this->dateTime->gmtDate(null, $syncAt) : null,
             ],
             ['last_update_at']
         );

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -150,13 +150,17 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
             ->limit(1);
 
         $lastSyncedAt = $connection->fetchRow($select);
-        $lastSyncedAt = !empty($lastSyncedAt) ? new \DateTimeImmutable($lastSyncedAt['last_update_at']) : null;
-
-        // Truncate subscribers synchronization state collection.
-        $connection->truncateTable($tableName);
+        $lastSyncedAt = !empty($lastSyncedAt)
+            ? (new \DateTimeImmutable($lastSyncedAt['last_update_at']))->format('Y-m-d H:i:s')
+            : null;
 
         foreach ($websites as $website) {
-            $this->subscribersSyncStateCollection->updateLastSyncedAt($website->getId(), $lastSyncedAt);
+            $this->configWriter->save(
+                'smaily/sync/lastSyncedAt',
+                $lastSyncedAt,
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES,
+                $website->getId()
+            );
         }
     }
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -52,7 +52,7 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
         if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $this->migration002();
         }
-        if (version_compare($context->getVersion(), '3.0.0', '<')) {
+        if (version_compare($context->getVersion(), '2.3.0', '<')) {
             $this->migration003();
         }
     }
@@ -131,7 +131,7 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
     }
 
     /**
-     * Run version 3.0.0 migrations.
+     * Run version 2.3.0 migrations.
      *
      * @access private
      * @return void

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -4,26 +4,36 @@ namespace Smaily\SmailyForMagento\Setup;
 
 use \Magento\Framework\Setup\ModuleDataSetupInterface;
 use \Magento\Framework\Setup\ModuleContextInterface;
+use Smaily\SmailyForMagento\Model\ResourceModel\SubscribersSyncState\Collection as SubscribersSyncStateCollection;
 
 class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
 {
     protected $configWriter;
     protected $scopeConfig;
+    protected $storeManager;
+
+    protected $subscribersSyncStateCollection;
 
     /**
      * Class constructor.
      *
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @access public
      * @return void
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        SubscribersSyncStateCollection $subscribersSyncStateCollection
     ) {
         $this->configWriter = $configWriter;
         $this->scopeConfig = $scopeConfig;
+        $this->storeManager = $storeManager;
+
+        $this->subscribersSyncStateCollection = $subscribersSyncStateCollection;
     }
 
     /**
@@ -41,6 +51,9 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
         }
         if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $this->migration002();
+        }
+        if (version_compare($context->getVersion(), '3.0.0', '<')) {
+            $this->migration003();
         }
     }
 
@@ -114,6 +127,36 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
             }
 
             $this->configWriter->save('smaily/sync/fields', implode(',', $fields));
+        }
+    }
+
+    /**
+     * Run version 3.0.0 migrations.
+     *
+     * @access private
+     * @return void
+     */
+    private function migration003()
+    {
+        $websites = $this->storeManager->getWebsites();
+
+        $connection = $this->subscribersSyncStateCollection->getConnection();
+        $tableName = $this->subscribersSyncStateCollection->getMainTable();
+
+        // Get stored last update date.
+        $select = $connection
+            ->select()
+            ->from($tableName, ['last_update_at'])
+            ->limit(1);
+
+        $lastSyncedAt = $connection->fetchRow($select);
+        $lastSyncedAt = !empty($lastSyncedAt) ? new \DateTimeImmutable($lastSyncedAt['last_update_at']) : null;
+
+        // Truncate subscribers synchronization state collection.
+        $connection->truncateTable($tableName);
+
+        foreach ($websites as $website) {
+            $this->subscribersSyncStateCollection->updateLastSyncedAt($website->getId(), $lastSyncedAt);
         }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -23,7 +23,7 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
         if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $this->migration001($installer);
         }
-        if (version_compare($context->getVersion(), '3.0.0', '<')) {
+        if (version_compare($context->getVersion(), '2.3.0', '<')) {
             $this->migration002($installer);
         }
 
@@ -59,7 +59,7 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
     }
 
     /**
-     * Run version 3.0.0 migrations.
+     * Run version 2.3.0 migrations.
      *
      * @param \Magento\Framework\Setup\SchemaSetupInterface $installer
      * @access private

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -23,6 +23,9 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
         if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $this->migration001($installer);
         }
+        if (version_compare($context->getVersion(), '3.0.0', '<')) {
+            $this->migration002($installer);
+        }
 
         $installer->endSetup();
     }
@@ -38,7 +41,7 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
     {
         $customerSyncTableName = 'smaily_customer_sync';
 
-        // Add ID column to smaily_customer_sync table.
+        // Add ID column to customer synchronization table.
         if ($installer->tableExists($customerSyncTableName)) {
             $installer->getConnection()->addColumn(
                 $installer->getTable($customerSyncTableName),
@@ -51,6 +54,46 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                     'unsigned' => true,
                 ]
+            );
+        }
+    }
+
+    /**
+     * Run version 3.0.0 migrations.
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $installer
+     * @access private
+     * @return void
+     */
+    private function migration002(SchemaSetupInterface $installer)
+    {
+        $customerSyncTableName = 'smaily_customer_sync';
+
+        if ($installer->tableExists($customerSyncTableName)) {
+            // Add Website column to customer synchronization table.
+            $installer->getConnection()->addColumn(
+                $installer->getTable($customerSyncTableName),
+                'website_id',
+                [
+                    'comment' => 'Website ID',
+                    'identity' => false,
+                    'nullable' => false,
+                    'primary' => false,
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                    'unsigned' => true,
+                ]
+            );
+
+            // Add unique index on Website column in customer synchronization table.
+            $installer->getConnection()->addIndex(
+                $installer->getTable($customerSyncTableName),
+                $installer->getIdxName(
+                    $customerSyncTableName,
+                    ['website_id'],
+                    \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
+                ),
+                ['website_id'],
+                \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
             );
         }
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -23,9 +23,6 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
         if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $this->migration001($installer);
         }
-        if (version_compare($context->getVersion(), '2.3.0', '<')) {
-            $this->migration002($installer);
-        }
 
         $installer->endSetup();
     }
@@ -54,46 +51,6 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                     'unsigned' => true,
                 ]
-            );
-        }
-    }
-
-    /**
-     * Run version 2.3.0 migrations.
-     *
-     * @param \Magento\Framework\Setup\SchemaSetupInterface $installer
-     * @access private
-     * @return void
-     */
-    private function migration002(SchemaSetupInterface $installer)
-    {
-        $customerSyncTableName = 'smaily_customer_sync';
-
-        if ($installer->tableExists($customerSyncTableName)) {
-            // Add Website column to customer synchronization table.
-            $installer->getConnection()->addColumn(
-                $installer->getTable($customerSyncTableName),
-                'website_id',
-                [
-                    'comment' => 'Website ID',
-                    'identity' => false,
-                    'nullable' => false,
-                    'primary' => false,
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
-                    'unsigned' => true,
-                ]
-            );
-
-            // Add unique index on Website column in customer synchronization table.
-            $installer->getConnection()->addIndex(
-                $installer->getTable($customerSyncTableName),
-                $installer->getIdxName(
-                    $customerSyncTableName,
-                    ['website_id'],
-                    \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
-                ),
-                ['website_id'],
-                \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
             );
         }
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -102,7 +102,7 @@
           <label>Last synchronized at</label>
           <frontend_model>\Smaily\SmailyForMagento\Block\Adminhtml\Form\Field\Datetime</frontend_model>
           <backend_model>\Smaily\SmailyForMagento\Model\Config\Backend\UTCTime</backend_model>
-          <comment><![CDATA[Value presents the synchronization changes range starting datetime (range ends always with CRON run datetime).<br><strong>Note!</strong> To synchronize all Newsletter Subscribers, empty the value.]]></comment>
+          <comment><![CDATA[Value presents the synchronization changes range starting datetime (range ends always with CRON run datetime). Time is in the website's configured timezone.<br><strong>Note!</strong> To synchronize all Newsletter Subscribers, empty the value.]]></comment>
         </field>
       </group>
       <group id="abandoned" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -65,10 +65,10 @@
         <field id="captchaApiKey" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
           <label>Google API Key</label>
           <comment><![CDATA[Create new site settings <a href="https://www.google.com/recaptcha/admin/create" target="_blank"> from here</a>.]]></comment>
-            <depends>
-              <field id="captchaType">google_captcha</field>
-              <field id="enableCaptcha">1</field>
-              <field id="enableNewsletterSubscriptions">1</field>
+          <depends>
+            <field id="captchaType">google_captcha</field>
+            <field id="enableCaptcha">1</field>
+            <field id="enableNewsletterSubscriptions">1</field>
           </depends>
           <validate>required-entry</validate>
         </field>
@@ -96,6 +96,13 @@
         <field id="frequency" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="0" showInStore="0">
           <label>Frequency</label>
           <source_model>Smaily\SmailyForMagento\Model\Config\Source\SubscribersSync\Frequency</source_model>
+        </field>
+        <field id="lastSyncedAt" translate="label" type="date" sortOrder="95" showInDefault="0" showInWebsite="1" showInStore="0">
+          <can_be_empty>1</can_be_empty>
+          <label>Last synchronized at</label>
+          <frontend_model>\Smaily\SmailyForMagento\Block\Adminhtml\Form\Field\Datetime</frontend_model>
+          <backend_model>\Smaily\SmailyForMagento\Model\Config\Backend\UTCTime</backend_model>
+          <comment><![CDATA[Value presents the synchronization changes range starting datetime (range ends always with CRON run datetime).<br><strong>Note!</strong> To synchronize all Newsletter Subscribers, empty the value.]]></comment>
         </field>
       </group>
       <group id="abandoned" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.2.0">
+    <module name="Smaily_SmailyForMagento" setup_version="2.3.0">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
Newsletter Subscribers last synchronization date is now website-based. This will resolve issues where new (or previously disabled) websites will not be able to do initial full synchronization.

Also change will add last synchronization date field to module configuration for the ease of resetting or changing next synchronization datetime range.