### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+### 2.6.0
+
+- Compare subscriber status change timestamp on newsletter subscriber sync [[#91](https://github.com/sendsmaily/smaily-magento-extension/pull/91)]
+- Fix newsletter subscribers sync unsubscribed status value [[#92](https://github.com/sendsmaily/smaily-magento-extension/pull/92)]
+
+
 ### 2.5.0
 
 - Add product image URL to abandoned cart data payload [[#88](https://github.com/sendsmaily/smaily-magento-extension/pull/88)]

--- a/Cron/SubscribersSync.php
+++ b/Cron/SubscribersSync.php
@@ -174,7 +174,8 @@ class SubscribersSync
 
                 $data = [
                     'email' => $subscriber['subscriber_email'],
-                    'is_unsubscribed' => (int) $subscriber['subscriber_status'] === 1 ? 0 : 1,
+                    'is_unsubscribed' => (int) $subscriber['subscriber_status']
+                        === \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED ? 0 : 1,
                     'store' => $customerStore !== null ? $customerStore->getName() : '',
                     'store_group' => $customerStoreGroup !== null ? $customerStoreGroup->getName() : '',
                     'store_website' => $website->getName(),
@@ -262,7 +263,7 @@ class SubscribersSync
                 )
                 ->where('main_table.store_id IN (?)', $storeIds)
                 ->where('main_table.subscriber_email IN (?)', array_keys($smailyUnsubscribers))
-                ->where('main_table.subscriber_status = ?', 1);
+                ->where('main_table.subscriber_status = ?', \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED);
 
             $subscribers = $this->resourceConnection->fetchAll($select);
 
@@ -280,7 +281,7 @@ class SubscribersSync
                     ->update(
                         $this->newsletterSubscribersCollection->getMaintable(),
                         [
-                            'subscriber_status' => 0,
+                            'subscriber_status' => \Magento\Newsletter\Model\Subscriber::STATUS_UNSUBSCRIBED,
                             'change_status_at' => $unsubscribedAt->format('Y-m-d H:i:s'),
                         ],
                         [

--- a/Setup/Patch/Data/NormalizeSyncUnsubscribeStatus.php
+++ b/Setup/Patch/Data/NormalizeSyncUnsubscribeStatus.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smaily\SmailyForMagento\Setup\Patch\Data;
+
+class NormalizeSyncUnsubscribeStatus implements \Magento\Framework\Setup\Patch\DataPatchInterface
+{
+    private $moduleDataSetup;
+
+    /**
+     * @param \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup,
+        \Magento\Newsletter\Model\ResourceModel\Subscriber\Collection $newsletterSubscribersCollection,
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+
+        $this->newsletterSubscribersCollection = $newsletterSubscribersCollection;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply()
+    {
+        $this->newsletterSubscribersCollection
+            ->getConnection()
+            ->update(
+                $this->newsletterSubscribersCollection->getMaintable(),
+                [
+                    'subscriber_status' => \Magento\Newsletter\Model\Subscriber::STATUS_UNSUBSCRIBED,
+                ],
+                [
+                    'subscriber_status = ?' => 0,
+                ]
+            );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getVersion()
+    {
+        return '2.6.0';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.5.0">
+    <module name="Smaily_SmailyForMagento" setup_version="2.6.0">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
- Compare subscriber status change timestamp on newsletter subscriber sync [[#91](https://github.com/sendsmaily/smaily-magento-extension/pull/91)]
- Fix newsletter subscribers sync unsubscribed status value [[#92](https://github.com/sendsmaily/smaily-magento-extension/pull/92)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations
- [x] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
