### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### 2.7.0
+
+- Add store, store group and website to abandoned cart payload - [[#96](https://github.com/sendsmaily/smaily-magento-extension/pull/96)]
+
+
 ### 2.6.0
 
 - Compare subscriber status change timestamp on newsletter subscriber sync [[#91](https://github.com/sendsmaily/smaily-magento-extension/pull/91)]

--- a/Cron/AbandonedCart.php
+++ b/Cron/AbandonedCart.php
@@ -245,8 +245,14 @@ class AbandonedCart
             ->load();
 
         foreach ($quotes as $quote) {
+            $store = $quote->getStore();
+            $storeGroup = $store !== null ? $store->getGroup() : null;
+
             $cart = [
                 'email' => $quote->getCustomerEmail(),
+                'store' => $store !== null ? $store->getName() : '',
+                'store_group' => $storeGroup !== null ? $storeGroup->getName() : '',
+                'store_website' => $website->getName(),
             ];
 
             $this->logger->debug('Triggering Abandoned Cart for quote', [

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ You can access RSS feed by visiting ulr `store_url/smaily/rss/feed` and you can 
 Here is a list of all the parameters available in Smaily email templating engine:
 
 - Customer first name: `{{ first_name }}`;
-- Customer last name: `{{ last_name }}`.
+- Customer last name: `{{ last_name }}`;
+- Store view: `{{ store }}`;
+- Store group: `{{ store_group }}`;
+- Website: `{{ store_website }}`.
 
 Up to 10 products can be received in Smaily templating engine. You can refrence each product with number 1-10 behind parameter name:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.6.0">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.0">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
- Add store, store group and website to abandoned cart payload - [[#96](https://github.com/sendsmaily/smaily-magento-extension/pull/96)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations
- [x] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
