### PR TITLE
Release 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.7.3
+
+- Fixes non-existing array key warning on subscribers synchronization [[#108](https://github.com/sendsmaily/smaily-magento-extension/pull/108)] (thanks @raulikesvatera)
+
 ### 2.7.2
 
 - PHP 8.2 compatibility [[#103](https://github.com/sendsmaily/smaily-magento-extension/pull/103)]

--- a/Cron/SubscribersSync.php
+++ b/Cron/SubscribersSync.php
@@ -249,7 +249,7 @@ class SubscribersSync
 
             $smailyUnsubscribers = [];
             foreach ($unsubscribers as $unsubscriber) {
-                $email = $unsubscriber['email'];
+                $email = strtolower($unsubscriber['email']);
                 $unsubscribedAt = new \DateTimeImmutable($unsubscriber['unsubscribed_at'], $timezoneLocal);
 
                 $smailyUnsubscribers[$email] = $unsubscribedAt->setTimezone($timezoneUTC);
@@ -268,7 +268,7 @@ class SubscribersSync
             $subscribers = $this->resourceConnection->fetchAll($select);
 
             foreach ($subscribers as $subscriber) {
-                $emailAddress = $subscriber['subscriber_email'];
+                $emailAddress = strtolower($subscriber['subscriber_email']);
                 $changeStatusAt = new \DateTimeImmutable($subscriber['change_status_at'], $timezoneUTC);
                 $unsubscribedAt = $smailyUnsubscribers[$emailAddress];
 

--- a/Setup/Patch/Data/NormalizeSyncUnsubscribeStatus.php
+++ b/Setup/Patch/Data/NormalizeSyncUnsubscribeStatus.php
@@ -15,7 +15,7 @@ class NormalizeSyncUnsubscribeStatus implements \Magento\Framework\Setup\Patch\D
      */
     public function __construct(
         \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup,
-        \Magento\Newsletter\Model\ResourceModel\Subscriber\Collection $newsletterSubscribersCollection,
+        \Magento\Newsletter\Model\ResourceModel\Subscriber\Collection $newsletterSubscribersCollection
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.2">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.3">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
- Fixes non-existing array key warning on subscribers synchronization [[#108](https://github.com/sendsmaily/smaily-magento-extension/pull/108)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations
- [x] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
