### PR TITLE
fix: Abandoned cart failing due to unknown field in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.7.4
+
+- Fixes an issue where abandoned cart synchronization can fail when unknown payload field is encountered.
+
 ### 2.7.3
 
 - Fixes non-existing array key warning on subscribers synchronization [[#108](https://github.com/sendsmaily/smaily-magento-extension/pull/108)] (thanks @raulikesvatera)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.7.4
 
-- Fixes an issue where abandoned cart synchronization can fail when unknown payload field is encountered.
+- Fixes an issue where abandoned cart synchronization can fail when unknown payload field is encountered.[[#111](https://github.com/sendsmaily/smaily-magento-extension/pull/111)]
 
 ### 2.7.3
 

--- a/Cron/AbandonedCart.php
+++ b/Cron/AbandonedCart.php
@@ -366,6 +366,10 @@ class AbandonedCart
         }
 
         foreach ($fields as $source) {
+            if (!array_key_exists($source, self::FIELDS_PREFIX_MAPPING)) {
+                continue;
+            }
+
             $target = self::FIELDS_PREFIX_MAPPING[$source] . '_' . $index;
             $payload[$target] = '';
         }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.3",
+    "version": "2.7.4",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.3">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.4">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
**Version changelog**

Abandoned cart payload population uses a function that maps user-selected configuration fields to their relevant payload values. When an unknown field is used to call the function, the method fails as there is no mapping for that key. Instead of failing with a PHP error, this PR will improve the function by skipping such values that are not found.
 [[#111](https://github.com/sendsmaily/smaily-magento-extension/pull/111)]


**Release checklist**

- [x] Added `release` tag to this pull request
- [ ] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [ ] Updated screenshots in assets folder
- [ ] Updated translations
- [ ] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [x] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
