### PR TITLE
templates: Improve PR template checklist description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 
 **Release checklist**
 
-- [ ] Added `release` tag to this pull request
+- [ ] Added `release` label to this pull request
 - [ ] Updated README.md
 - [ ] Updated CHANGELOG.md
 - [ ] Updated composer.json


### PR DESCRIPTION
The release checklist uses the term `tag` for adding a label, but the GitHub term for the tag is `label`. We should be using the same language in the PR template as in the UI.
