### PR TITLE
fix: Items placement in RSS feed structure

### DIFF
--- a/Controller/Rss/Feed.php
+++ b/Controller/Rss/Feed.php
@@ -102,7 +102,7 @@ class Feed extends \Magento\Framework\App\Action\Action
             }
 
             // Compile feed item.
-            $item = $feed->addChild('item');
+            $item = $channel->addChild('item');
             $item->addChildWithCDATA('title', $product->getName());
             $item->addChildWithCDATA('link', $productUrl);
             $item->addChildWithCData('guid', $productUrl)


### PR DESCRIPTION
`item` entities must exist inside `channel` entity for the RSS feed to be valid.