### PR TITLE
Release 2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.7.6
+
+- fix: RSS feed rendering with missing description value [[#118](https://github.com/sendsmaily/smaily-magento-extension/pull/118)]
+
 ### 2.7.5
 
 - fix: Items placement in RSS feed structure [[#114](https://github.com/sendsmaily/smaily-magento-extension/pull/114)]

--- a/Model/XML.php
+++ b/Model/XML.php
@@ -8,19 +8,19 @@ class XML extends \SimpleXMLElement
      * Add child node with CDATA wrapped value.
      *
      * @param string $name
-     * @param string|null $value
+     * @param string $value
      * @param string|null $namespace
      * @access public
      * @return \SimpleXMLElement|null
      */
-    public function addChildWithCDATA($name, $value = null, $namespace = null)
+    public function addChildWithCDATA($name, $value = "", $namespace = null)
     {
         $child = $this->addChild($name, null, $namespace);
 
         if ($child !== null) {
             $node = dom_import_simplexml($child);
             $document = $node->ownerDocument;
-            $node->appendChild($document->createCDATASection($value));
+            $node->appendChild($document->createCDATASection((string) $value));
         }
 
         return $child;

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.5">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.6">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
- Fix RSS feed rendering with missing description value [[#118](https://github.com/sendsmaily/smaily-magento-extension/pull/118)]

**Release checklist**

- [x] Added `release` label to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations
- [x] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
