### PR TITLE
abandoned cart: Add extra mandatory fields to request payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.7.7
+
+- Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload
+- Does not opt-in customers who received abandoned cart email
+
 ### 2.7.6
 
 - fix: RSS feed rendering with missing description value [[#118](https://github.com/sendsmaily/smaily-magento-extension/pull/118)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.7.7
 
 - Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload
-- Does not opt-in customers who received abandoned cart email
+- Does not opt-in unsubscribed customers who have received abandoned cart email
 
 ### 2.7.6
 

--- a/Cron/AbandonedCart.php
+++ b/Cron/AbandonedCart.php
@@ -320,8 +320,10 @@ class AbandonedCart
             // Note! This is done one-by-one to avoid potential issues with sending abandoned cart
             // messages to recipients over-and-over.
             $payload = [
-                'autoresponder' => $workflowId,
                 'addresses' => [$cart],
+                'autoresponder' => $workflowId,
+                'force_opt_in' => false,
+                'is_abandoned_cart' => 'true',
             ];
 
             try {

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Here is a list of all the parameters available in Smaily email templating engine
 - Store view: `{{ store }}`;
 - Store group: `{{ store_group }}`;
 - Website: `{{ store_website }}`.
+- Is abandoned cart: `{{ is_abandoned_cart }}`;
 
 Up to 10 products can be received in Smaily templating engine. You can refrence each product with number 1-10 behind parameter name:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.6",
+    "version": "2.7.7",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.6">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.7">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
**Version changelog**

- Adds `is_abandoned_cart` field to request payload for better contact filtering in Smaily.
- Stops subscribing unsubscribed customers in case of receiving abandoned cart emails.

**Release checklist**

- [x] Added `release` label to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [ ] Updated screenshots in assets folder
- [ ] Updated translations
- [ ] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
