### PR TITLE
Include taxes in cart item prices and in RSS-feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 
-### 2.7.8
+### 2.8.0
+
+> Notice! This version updates the price values in abandoned cart emails and RSS feed items to include taxes. These prices now match what customers see in the storefront. For B2B (business-to-business) stores, where tax-exclusive pricing may be expected, this behavior might not be suitable.
 
 - Abandoned cart `product_price` and `product_base_price` now also include taxes.
 - RSS-feed now shows prices including taxes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+### 2.7.8
+
+- Abandoned cart `product_price` and `product_base_price` now also include taxes.
+
 ### 2.7.7
 
 - Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### 2.7.8
 
 - Abandoned cart `product_price` and `product_base_price` now also include taxes.
+- RSS-feed now shows prices including taxes.
+- RSS-feed uses parent product URL-s for configurable products that are not visible individually.
 
 ### 2.7.7
 

--- a/Controller/Rss/Feed.php
+++ b/Controller/Rss/Feed.php
@@ -104,9 +104,8 @@ class Feed extends \Magento\Framework\App\Action\Action
                 // Probably a grouped product.
                 continue;
             }
-            $specialPrice = $this->getFinalPriceIncludingTax($product);
+            $finalPrice = $this->getFinalPriceIncludingTax($product);
             $discount = $this->calculateDiscountPercentage($product);
-
             $productUrl = $this->getProductUrl($product);
 
             // Compile feed item.
@@ -122,10 +121,10 @@ class Feed extends \Magento\Framework\App\Action\Action
 
             // Add pricing information to feed item.
             if ($discount > 0) {
-                $formattedSpecialPrice = $this->pricingHelper->currencyByStore($specialPrice, $store, true, false);
+                $formattedFinalPrice = $this->pricingHelper->currencyByStore($finalPrice, $store, true, false);
                 $formattedPrice = $this->pricingHelper->currencyByStore($price, $store, true, false);
 
-                $item->addChild('price', $formattedSpecialPrice, self::SMLY_NAMESPACE_XSD);
+                $item->addChild('price', $formattedFinalPrice, self::SMLY_NAMESPACE_XSD);
                 $item->addChild('old_price', $formattedPrice, self::SMLY_NAMESPACE_XSD);
                 $item->addChild('discount', $discount . '%', self::SMLY_NAMESPACE_XSD);
             } else {

--- a/Cron/AbandonedCart.php
+++ b/Cron/AbandonedCart.php
@@ -306,11 +306,11 @@ class AbandonedCart
                 }
                 if (in_array('price', $fields, true)) {
                     $cart['product_price_' . $productsIndex] = $this->pricingHelper
-                        ->currencyByStore($item->getPrice(), $quote->getStore(), true, false);
+                        ->currencyByStore($item->getPriceInclTax(), $quote->getStore(), true, false);
                 }
                 if (in_array('base_price', $fields, true)) {
                     $cart['product_base_price_' . $productsIndex] = $this->pricingHelper
-                        ->currencyByStore($item->getBasePrice(), $quote->getStore(), true, false);
+                        ->currencyByStore($item->getBasePriceInclTax(), $quote->getStore(), true, false);
                 }
             }
 

--- a/Cron/AbandonedCart.php
+++ b/Cron/AbandonedCart.php
@@ -325,11 +325,11 @@ class AbandonedCart
                     $taxRequest->setProductClassId($productItem->getTaxClassId());
                     $taxRate = $this->taxCalculation->getRate($taxRequest);
                     $priceExclTax = $productItem->getPrice();
-                    $priceInclTax = $this->taxCalculation->calcTaxAmount(
+                    $taxAmount = $this->taxCalculation->calcTaxAmount(
                         $priceExclTax,
                         $taxRate,
                     );
-                    $originalPriceInclTax = $priceExclTax + $priceInclTax;
+                    $originalPriceInclTax = $priceExclTax + $taxAmount;
 
                     $cart['product_base_price_' . $productsIndex] = $this->pricingHelper
                         ->currencyByStore($originalPriceInclTax, $quote->getStore(), true, false);

--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ Up to 10 products can be received in Smaily templating engine. You can refrence 
 
 - Product price: `{{ product_price_[1-10] }}`;
 
+Product price is the end price that the customer sees in the cart. If you have a special price set for the product, it will be shown here. This price also includes taxes and discounts.
+
 - Product base price: `{{ product_base_price_[1-10] }}`.
+
+Product base price is the price that is set in the product edit page. This price also includes taxes but no discounts.
 
 Also you can determine if customer had more than 10 items in cart:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.8",
+    "version": "2.8.0",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "smaily/smailyformagento",
     "description": "Smaily extension for Magento 2",
-    "version": "2.7.7",
+    "version": "2.7.8",
     "type": "magento2-module",
     "license": "GPL-3.0-only",
     "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.8">
+    <module name="Smaily_SmailyForMagento" setup_version="2.8.0">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smaily_SmailyForMagento" setup_version="2.7.7">
+    <module name="Smaily_SmailyForMagento" setup_version="2.7.8">
         <sequence>
             <module name="Magento_Newsletter" />
             <module name="Magento_Captcha" />


### PR DESCRIPTION
**Version changelog**

Abandoned cart emails that exclude taxes can give customers a misleading impression of a discount. If the email shows product prices without tax, they may appear lower than expected, which can confuse customers when they return to the store and see higher prices.

To ensure a consistent experience, the prices shown in abandoned cart emails should match those displayed on the storefront.

**Release checklist**

- [x] Added `release` label to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated composer.json
- [x] Updated plugin version number
- [ ] Updated screenshots in assets folder
- [ ] Updated translations
- [ ] Updated USERGUIDE.md
- [x] Ran pre-release checks. [Testing module before submitting for review](https://github.com/sendsmaily/smaily-magento-extension/blob/master/CONTRIBUTING.md#testing-module-before-submitting-for-review)

**After PR merge**

- [ ] Create a release
- [ ] Submit built release ZIP-file for Magento review

> When Magento should reject the code review, then create a patch and re-release the version in GitHub.

**After acceptance in Magento Marketplace**

- [ ] Pinged code owners to inform marketing about new version
