### PR TITLE
chore: Switch to Composer v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php')
     && EXPECTED_CHECKSUM="$(curl https://composer.github.io/installer.sig)" \
     && ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', '/tmp/composer-setup.php');")" \
     && test "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" \
-    && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --1 \
+    && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer \
     && rm /tmp/composer-setup.php \
     && chown www-data:www-data $COMPOSER_HOME
 


### PR DESCRIPTION
Composer v1 access to Packagist HTTP API was shut down in September 2025.