### PR TITLE
chore: Upgrade sandbox Magento to version 2.4.8-p4

### DIFF
--- a/.sandbox/entrypoint.sh
+++ b/.sandbox/entrypoint.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Wait for MySQL to start.
-mysql_ready() {
-    mysqladmin ping --host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_PASSWORD > /dev/null 2>&1
-}
-while !(mysql_ready); do
-    sleep 1
-    echo "Waiting for MySQL to finish start up..."
-done
-
-# Wait for Elasticsearch to start.
-elastic_ready() {
-    curl -X GET "elastic:9200/_cat/nodes?v=true&pretty" > /dev/null 2>&1
-}
-while !(elastic_ready); do
-    sleep 1
-    echo "Waiting for Elasticsearch to finish start up..."
-done
-
 # Install sample data if requested.
 if [ "${MAGENTO_SAMPLEDATA}" = "1" ]; then
     echo "Installing sample-data..."
@@ -40,8 +22,9 @@ bin/magento setup:install \
     --use-secure=0 \
     --base-url-secure= \
     --use-secure-admin=0 \
-    --elasticsearch-host=elastic \
-    --elasticsearch-port=9200 \
+    --search-engine=opensearch \
+    --opensearch-host=opensearch \
+    --opensearch-port=9200 \
     --admin-firstname=Smaily \
     --admin-lastname=DevOps \
     --admin-email=${MAGENTO_ADMIN_EMAIL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 
-# Install Magento requirements.
+# Install required packages.
 RUN apt-get update \
     && apt-get install -y \
         git \
@@ -19,9 +19,14 @@ RUN apt-get update \
         unzip \
         # MariaDB for mysqladmin ping in entrypoint
         mariadb-client \
-    && pecl install mcrypt-1.0.6 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install PHP extensions.
+RUN pecl install mcrypt-1.0.7 \
     && docker-php-ext-enable mcrypt \
     && docker-php-ext-install bcmath \
+    && docker-php-ext-install ftp \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-install intl \
@@ -30,9 +35,7 @@ RUN apt-get update \
     && docker-php-ext-install soap \
     && docker-php-ext-install sockets \
     && docker-php-ext-install xsl \
-    && docker-php-ext-install zip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && docker-php-ext-install zip
 
 # Prepare server for Magento.
 RUN a2enmod rewrite \
@@ -55,7 +58,7 @@ RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php')
 USER www-data
 
 # Download and install Magento.
-ENV MAGENTO_VERSION 2.4.6
+ENV MAGENTO_VERSION 2.4.8-p4
 RUN composer create-project magento/community-edition=${MAGENTO_VERSION} ./ \
     && chmod +x bin/magento \
     && git clone https://github.com/magento/magento2-sample-data.git /sample-data \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
-version: '3.7'
-
+---
 services:
   magento2:
     container_name: magento2
@@ -26,34 +25,49 @@ services:
     - data:/var/www/html
     - ./:/var/www/html/app/code/Smaily/SmailyForMagento
     depends_on:
-    - db
-    - elastic
+      db:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
 
   db:
     container_name: magento2_db
-    image: mysql:5.7
+    image: mysql:8.4
+    command: ["--tls-version=", "--admin-tls-version="]
     environment:
     - MYSQL_DATABASE=magento2
     - MYSQL_ROOT_PASSWORD=root
     volumes:
     - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-S", "/var/run/mysqld/mysqld.sock"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ulimits:
       nproc: 65535
       nofile:
         soft: 26677
         hard: 46677
 
-  elastic:
-    container_name: magento2_elastic
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3
+  opensearch:
+    container_name: magento2_opensearch
+    image: opensearchproject/opensearch:2
     ports:
     - '9200:9200'
     - '9300:9300'
     environment:
     - discovery.type=single-node
-    - ES_JAVA_OPTS=-Xms256m -Xmx256m
+    - OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m
+    - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Smaily.dev1
+    - DISABLE_SECURITY_PLUGIN=true
     volumes:
-    - elastic-data:/usr/share/elasticsearch/data
+    - opensearch-data:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   phpmyadmin:
     container_name: magento2_phpmyadmin
@@ -73,5 +87,5 @@ volumes:
     name: docker_magento2-data
   db-data:
     name: docker_magento2-db-data
-  elastic-data:
-    name: docker_magento2-elastic-data
+  opensearch-data:
+    name: docker_magento2-opensearch-data


### PR DESCRIPTION
With Magento 2.4.8-p4
* PHP version was bumped from 8.2 to 8.3,
* mcrypt was upgraded from 1.0.6 to 1.0.7,
* PHP `ftp` extension was added,
* MySQL was bumped from 5.7 to 8.4,
* Elasticsearch was replaced by OpenSearch,
* and MySQL and OpenSearch readiness is now checked via Docker health checks.