### PR TITLE
sandbox: Use linux default user as container user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/launch.json
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN pecl install mcrypt-1.0.7 \
     && docker-php-ext-install xsl \
     && docker-php-ext-install zip
 
+# Align www-data UID/GID with host developer UID so volume-mounted files are writable by both.
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
+
 # Prepare server for Magento.
 RUN a2enmod rewrite \
     && echo "memory_limit=2048M" > /usr/local/etc/php/conf.d/memory-limit.ini \
@@ -53,7 +56,11 @@ RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php')
     && test "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" \
     && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer \
     && rm /tmp/composer-setup.php \
-    && chown www-data:www-data $COMPOSER_HOME
+    && chown www-data:www-data /var/www
+
+# Create a directory for VSCode Server and give ownership to www-data.
+RUN mkdir /var/www/.devcontainer \
+    && chown www-data:www-data /var/www/.devcontainer
 
 USER www-data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,6 @@ RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php')
     && rm /tmp/composer-setup.php \
     && chown www-data:www-data /var/www
 
-# Create a directory for VSCode Server and give ownership to www-data.
-RUN mkdir /var/www/.devcontainer \
-    && chown www-data:www-data /var/www/.devcontainer
-
 USER www-data
 
 # Download and install Magento.


### PR DESCRIPTION
This change improves the user development flow by allowing the use of remote containers. The user for www-data is 33, and module files that are volume-mounted to the container belong to user 1000. This creates a conflict when modifying files during development.

This PR defaults the www-data user in the container to 1000, allowing better DX when using remote containers for development.